### PR TITLE
PYTHON already defined by AZ_PYTHON in configure.ac

### DIFF
--- a/pywrap/Makefile.am
+++ b/pywrap/Makefile.am
@@ -6,7 +6,6 @@ apfel_wrap.cc apfel.py: apfel.i
 	swig -c++ -python -I$(HEPMCINCPATH) -I$(top_srcdir)/include -o apfel_wrap.cc $<
 
 AM_CXXFLAGS += -Wno-long-long
-PYTHON = python
 
 all-local: apfel_wrap.cc
 	$(PYTHON) setup.py build


### PR DESCRIPTION
Hello,

on my system (Arch Linux) python3 is the default and installed to /usr/bin/python. Since python3 seems not be supported and fails with
```
python setup.py build
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    import commands
ImportError: No module named 'commands'
```

usually one can just force configure to use python2 by supplying the env PYTHON with
`$ PYTHON=/usr/bin/python2 ./configure xyz`
but the PYTHON variable is then overwritten again in pywrap/Makefile.am causing the build process to fail. Since PYTHON is already defined by AZ_PYTHON it shouldn't be neccesary to define it again in the pywrap/Makefile.am.

Cheers,
Georg