### PR TITLE
Some fixes to avoid crashes when compiled with the stack-protector-strong flag

### DIFF
--- a/src/DIS/SelectCharge.f
+++ b/src/DIS/SelectCharge.f
@@ -16,20 +16,20 @@
 *
       character*7 selch
 *
-      if(selch(1:4).eq."down")then
-         SelectedCharge = selch(1:4)
-      elseif(selch(1:2).eq."up")then
+      if(selch(1:2).eq."up")then
          SelectedCharge = selch(1:2)
-      elseif(selch(1:7).eq."strange")then
-         SelectedCharge = selch(1:7)
-      elseif(selch(1:5).eq."charm")then
-         SelectedCharge = selch(1:5)
-      elseif(selch(1:6).eq."bottom")then
-         SelectedCharge = selch(1:6)
       elseif(selch(1:3).eq."top")then
          SelectedCharge = selch(1:3)
       elseif(selch(1:3).eq."all")then
          SelectedCharge = selch(1:3)
+      elseif(selch(1:4).eq."down")then
+         SelectedCharge = selch(1:4)
+      elseif(selch(1:5).eq."charm")then
+         SelectedCharge = selch(1:5)
+      elseif(selch(1:6).eq."bottom")then
+         SelectedCharge = selch(1:6)
+      elseif(selch(1:7).eq."strange")then
+         SelectedCharge = selch(1:7)
       endif
       InSelectedCharge = "done"
 *

--- a/src/Evolution/SetPDFSet.f
+++ b/src/Evolution/SetPDFSet.f
@@ -15,7 +15,7 @@
 *     Variables
 *
       integer ln
-      character name*(*)
+      character*(*) name
       logical islhapdf6
 
 *     Sorting if/else conditions based on the size to avoid leaks

--- a/src/Evolution/SetPDFSet.f
+++ b/src/Evolution/SetPDFSet.f
@@ -15,7 +15,7 @@
 *     Variables
 *
       integer ln
-      character*(*) name
+      character*100 name
       logical islhapdf6
 
 *     Sorting if/else conditions based on the size to avoid leaks
@@ -42,11 +42,9 @@
       elseif(name(1:7).eq."kretzer")then
          ln = 7
       elseif(name(1:8).eq."external")then
-         if(len(name).gt.9) then
-            if(name(9:9).eq."1") ln = 9
-         else
-            ln = 8
-         endif
+         ln = 8
+      elseif(name(1:9).eq."external1") then
+         ln = 9
       elseif(name(1:11).eq."repexternal")then
          ln = 11
       elseif(name(1:12).eq."leptexternal")then
@@ -54,12 +52,10 @@
 *
 *     Pretabulated PDFs (for internal use).
 *
-      elseif(name(1:12).eq."pretabulated")then
-         if(len(name).gt.12) then
-            if(name(13:13).eq."1") ln = 13
-         else
-            ln = 12
-         endif
+      elseif(name(1:12).eq."pretabulated")then         
+         ln = 12
+      elseif(name(1:13).eq."pretabulated1")then
+         ln = 13
 *
 *     External LHAPDF grids
 *

--- a/src/Evolution/SetPDFSet.f
+++ b/src/Evolution/SetPDFSet.f
@@ -15,46 +15,48 @@
 *     Variables
 *
       integer ln
-c      character name*(*)
-      character*100 name
+      character name*(*)
       logical islhapdf6
+
+*     Sorting if/else conditions based on the size to avoid leaks
+
+*
+*     HKNS parametrization at Q2 = 1 GeV^2 of the light partons
+*     for pi+ taken at NLO from hep-ph/0702250 (used for the benchmark against MELA).
+*
+      if(name(1:4).eq."MELA")then
+         ln = 4
 *
 *     Internal PDFs
 *
-      if(name(1:5).eq."ToyLH")then
+      elseif(name(1:5).eq."ToyLH")then
+         ln = 5
+      elseif(name(1:5).eq."apfel")then
          ln = 5
       elseif(name(1:7).eq."private")then
          ln = 7
-      elseif(name(1:5).eq."apfel")then
-         ln = 5
-      elseif(name(1:8).eq."external")then
-         if(name(9:9).eq."1")then
-            ln = 9
-         else
-            ln = 8
-         endif
-      elseif(name(1:12).eq."leptexternal")then
-         ln = 12
-      elseif(name(1:11).eq."repexternal")then
-         ln = 11
 *
 *     Kretzer's parametrization at Q2 = 0.4 GeV^2 of the light partons
 *     for pi+ taken at NLO from hep-ph/0003177.
 *
       elseif(name(1:7).eq."kretzer")then
          ln = 7
-*
-*     HKNS parametrization at Q2 = 1 GeV^2 of the light partons
-*     for pi+ taken at NLO from hep-ph/0702250 (used for the benchmark against MELA).
-*
-      elseif(name(1:4).eq."MELA")then
-         ln = 4
+      elseif(name(1:8).eq."external")then
+         if(len(name).gt.9) then
+            if(name(9:9).eq."1") ln = 9
+         else
+            ln = 8
+         endif
+      elseif(name(1:11).eq."repexternal")then
+         ln = 11
+      elseif(name(1:12).eq."leptexternal")then
+         ln = 12
 *
 *     Pretabulated PDFs (for internal use).
 *
       elseif(name(1:12).eq."pretabulated")then
-         if(name(13:13).eq."1")then
-            ln = 13
+         if(len(name).gt.12) then
+            if(name(13:13).eq."1") ln = 13
          else
             ln = 12
          endif

--- a/src/Evolution/a_QED.f
+++ b/src/Evolution/a_QED.f
@@ -34,7 +34,7 @@
       integer nfi,nff
       integer Nl_FF,nli,nlf
       integer dnf,snf
-      double precision mur2th(3:6),mur2lep(3)
+      double precision mur2th(3:6),mur2lep(4)
       double precision mur2,mur20
       double precision aqedi,aqedr0
       double precision alphaqedev
@@ -217,7 +217,7 @@ c      return
                aqedr0 = aqedi
                mur20  = mur2
                mur2   = mur2lep(il+sgnl)
-               if(sgnl.gt.0) mur2 = mur2lep(il+sgnl+1)
+               if(sgnl.lt.0) mur2 = mur2lep(il+sgnl+1)
                if(il.eq.nlf-sgnl) mur2 = kren * mu2f
             enddo
             a_QED = aqedi


### PR DESCRIPTION
Changes in `SetPDFSet` and `SelectCharge` are minimalist, and probably not optimal. One should test for the size of the string before actually building a sub-string. 

Closes #5 , https://github.com/NNPDF/apfelcomb/issues/9