### PR TITLE
Corrected order for CHORUS non-isoscalar observable

### DIFF
--- a/src/DIS/FKObservables.f
+++ b/src/DIS/FKObservables.f
@@ -275,66 +275,6 @@
 *
 ****  Neutrino scattering Reduced Cross-Section (light)
 *
-      elseif(obs(1:9).eq."DIS_SNU_L")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKObservables = ( ypc * F2light(x) 
-     1                 -   y2  * FLlight(x)
-     2                 +   ym  * F3light(x) )
-         FKObservables = norm * FKObservables
-*
-****  Antineutrino scattering Reduced Cross-Section (light)
-*
-      elseif(obs(1:9).eq."DIS_SNB_L")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKObservables = ( ypc * F2light(x) 
-     1                 -   y2  * FLlight(x)
-     2                 -   ym  * F3light(x) )
-         FKObservables = norm * FKObservables
-*
-****  Neutrino scattering Reduced Cross-Section (charm)
-*
-      elseif(obs(1:9).eq."DIS_SNU_C")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKObservables = ( ypc * F2charm(x) 
-     1                 -   y2  * FLcharm(x)
-     2                 +   ym  * F3charm(x) )
-         FKObservables = norm * FKObservables
-*
-****  Antineutrino scattering Reduced Cross-Section (charm)
-*
-      elseif(obs(1:9).eq."DIS_SNB_C")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKObservables = ( ypc * F2charm(x) 
-     1                 -   y2  * FLcharm(x)
-     2                 -   ym  * F3charm(x) )
-         FKObservables = norm * FKObservables
-*
-****  Neutrino scattering Reduced Cross-Section (inclusive)
-*
-      elseif(obs(1:7).eq."DIS_SNU")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKObservables = ( ypc * F2total(x) 
-     1                 -   y2  * FLtotal(x)
-     2                 +   ym  * F3total(x) )
-         FKObservables = norm * FKObservables
-*
-****  Antineutrino scattering Reduced Cross-Section (inclusive)
-*
-      elseif(obs(1:7).eq."DIS_SNB")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKObservables = ( ypc * F2total(x) 
-     1                 -   y2  * FLtotal(x)
-     2                 -   ym  * F3total(x) )
-         FKObservables = norm * FKObservables
-*
-****  Neutrino scattering Reduced Cross-Section (light)
-*
       elseif(obs(1:12).eq."DIS_SNU_L_Pb")then
          ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
          norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
@@ -392,6 +332,67 @@
      1                 -   y2  * FLtotal(x)
      2                 -   ym  * F3total(x) )
          FKObservables = norm * FKObservables
+*
+****  Neutrino scattering Reduced Cross-Section (light)
+*
+      elseif(obs(1:9).eq."DIS_SNU_L")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKObservables = ( ypc * F2light(x) 
+     1                 -   y2  * FLlight(x)
+     2                 +   ym  * F3light(x) )
+         FKObservables = norm * FKObservables
+*
+****  Antineutrino scattering Reduced Cross-Section (light)
+*
+      elseif(obs(1:9).eq."DIS_SNB_L")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKObservables = ( ypc * F2light(x) 
+     1                 -   y2  * FLlight(x)
+     2                 -   ym  * F3light(x) )
+         FKObservables = norm * FKObservables
+*
+****  Neutrino scattering Reduced Cross-Section (charm)
+*
+      elseif(obs(1:9).eq."DIS_SNU_C")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKObservables = ( ypc * F2charm(x) 
+     1                 -   y2  * FLcharm(x)
+     2                 +   ym  * F3charm(x) )
+         FKObservables = norm * FKObservables
+*
+****  Antineutrino scattering Reduced Cross-Section (charm)
+*
+      elseif(obs(1:9).eq."DIS_SNB_C")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKObservables = ( ypc * F2charm(x) 
+     1                 -   y2  * FLcharm(x)
+     2                 -   ym  * F3charm(x) )
+         FKObservables = norm * FKObservables
+*
+****  Neutrino scattering Reduced Cross-Section (inclusive)
+*
+      elseif(obs(1:7).eq."DIS_SNU")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKObservables = ( ypc * F2total(x) 
+     1                 -   y2  * FLtotal(x)
+     2                 +   ym  * F3total(x) )
+         FKObservables = norm * FKObservables
+*
+****  Antineutrino scattering Reduced Cross-Section (inclusive)
+*
+      elseif(obs(1:7).eq."DIS_SNB")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKObservables = ( ypc * F2total(x) 
+     1                 -   y2  * FLtotal(x)
+     2                 -   ym  * F3total(x) )
+         FKObservables = norm * FKObservables
+
 *
 ****  Dimuon neutrino and anti-neutrino cross section
 *

--- a/src/DIS/FKSimulator.f
+++ b/src/DIS/FKSimulator.f
@@ -274,66 +274,6 @@
 *
 ****  Neutrino scattering Reduced Cross-Section (light)
 *
-      elseif(obs(1:9).eq."DIS_SNU_L")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKSimulator = ( ypc * ExternalDISOperator("F2",3,i,x,beta) 
-     1               -   y2  * ExternalDISOperator("FL",3,i,x,beta)
-     2               +   ym  * ExternalDISOperator("F3",3,i,x,beta) )
-         FKSimulator = norm * FKSimulator
-*
-****  Antineutrino scattering Reduced Cross-Section (light)
-*
-      elseif(obs(1:9).eq."DIS_SNB_L")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKSimulator = ( ypc * ExternalDISOperator("F2",3,i,x,beta) 
-     1               -   y2  * ExternalDISOperator("FL",3,i,x,beta)
-     2               -   ym  * ExternalDISOperator("F3",3,i,x,beta) )
-         FKSimulator = norm * FKSimulator
-*
-****  Neutrino scattering Reduced Cross-Section (charm)
-*
-      elseif(obs(1:9).eq."DIS_SNU_C")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKSimulator = ( ypc * ExternalDISOperator("F2",4,i,x,beta) 
-     1               -   y2  * ExternalDISOperator("FL",4,i,x,beta)
-     2               +   ym  * ExternalDISOperator("F3",4,i,x,beta) )
-         FKSimulator = norm * FKSimulator
-*
-****  Antineutrino scattering Reduced Cross-Section (charm)
-*
-      elseif(obs(1:9).eq."DIS_SNB_C")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKSimulator = ( ypc * ExternalDISOperator("F2",4,i,x,beta) 
-     1               -   y2  * ExternalDISOperator("FL",4,i,x,beta)
-     2               -   ym  * ExternalDISOperator("F3",4,i,x,beta) )
-         FKSimulator = norm * FKSimulator
-*
-****  Neutrino scattering Reduced Cross-Section (inclusive)
-*
-      elseif(obs(1:7).eq."DIS_SNU")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKSimulator = ( ypc * ExternalDISOperator("F2",7,i,x,beta) 
-     1               -   y2  * ExternalDISOperator("FL",7,i,x,beta)
-     2               +   ym  * ExternalDISOperator("F3",7,i,x,beta) )
-         FKSimulator = norm * FKSimulator
-*
-****  Antineutrino scattering Reduced Cross-Section (inclusive)
-*
-      elseif(obs(1:7).eq."DIS_SNB")then
-         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
-         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
-         FKSimulator = ( ypc * ExternalDISOperator("F2",7,i,x,beta) 
-     1               -   y2  * ExternalDISOperator("FL",7,i,x,beta)
-     2               -   ym  * ExternalDISOperator("F3",7,i,x,beta) )
-         FKSimulator = norm * FKSimulator
-*
-****  Neutrino scattering Reduced Cross-Section (light)
-*
       elseif(obs(1:12).eq."DIS_SNU_L_Pb")then
          ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
          norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
@@ -385,6 +325,66 @@
 ****  Antineutrino scattering Reduced Cross-Section (inclusive)
 *
       elseif(obs(1:10).eq."DIS_SNB_Pb")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKSimulator = ( ypc * ExternalDISOperator("F2",7,i,x,beta) 
+     1               -   y2  * ExternalDISOperator("FL",7,i,x,beta)
+     2               -   ym  * ExternalDISOperator("F3",7,i,x,beta) )
+         FKSimulator = norm * FKSimulator
+*
+****  Neutrino scattering Reduced Cross-Section (light)
+*
+      elseif(obs(1:9).eq."DIS_SNU_L")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKSimulator = ( ypc * ExternalDISOperator("F2",3,i,x,beta) 
+     1               -   y2  * ExternalDISOperator("FL",3,i,x,beta)
+     2               +   ym  * ExternalDISOperator("F3",3,i,x,beta) )
+         FKSimulator = norm * FKSimulator
+*
+****  Antineutrino scattering Reduced Cross-Section (light)
+*
+      elseif(obs(1:9).eq."DIS_SNB_L")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKSimulator = ( ypc * ExternalDISOperator("F2",3,i,x,beta) 
+     1               -   y2  * ExternalDISOperator("FL",3,i,x,beta)
+     2               -   ym  * ExternalDISOperator("F3",3,i,x,beta) )
+         FKSimulator = norm * FKSimulator
+*
+****  Neutrino scattering Reduced Cross-Section (charm)
+*
+      elseif(obs(1:9).eq."DIS_SNU_C")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKSimulator = ( ypc * ExternalDISOperator("F2",4,i,x,beta) 
+     1               -   y2  * ExternalDISOperator("FL",4,i,x,beta)
+     2               +   ym  * ExternalDISOperator("F3",4,i,x,beta) )
+         FKSimulator = norm * FKSimulator
+*
+****  Antineutrino scattering Reduced Cross-Section (charm)
+*
+      elseif(obs(1:9).eq."DIS_SNB_C")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKSimulator = ( ypc * ExternalDISOperator("F2",4,i,x,beta) 
+     1               -   y2  * ExternalDISOperator("FL",4,i,x,beta)
+     2               -   ym  * ExternalDISOperator("F3",4,i,x,beta) )
+         FKSimulator = norm * FKSimulator
+*
+****  Neutrino scattering Reduced Cross-Section (inclusive)
+*
+      elseif(obs(1:7).eq."DIS_SNU")then
+         ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
+         norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
+         FKSimulator = ( ypc * ExternalDISOperator("F2",7,i,x,beta) 
+     1               -   y2  * ExternalDISOperator("FL",7,i,x,beta)
+     2               +   ym  * ExternalDISOperator("F3",7,i,x,beta) )
+         FKSimulator = norm * FKSimulator
+*
+****  Antineutrino scattering Reduced Cross-Section (inclusive)
+*
+      elseif(obs(1:7).eq."DIS_SNB")then
          ypc  = yp - 2d0 * ( MN * x * y )**2 / Q2
          norm = conv * GF2 * MN / ( 2d0 * pi * ( 1d0 + Q2 / MW2 )**2 )
          FKSimulator = ( ypc * ExternalDISOperator("F2",7,i,x,beta) 

--- a/src/DIS/SetFKObservable.f
+++ b/src/DIS/SetFKObservable.f
@@ -276,48 +276,6 @@
 *
 ****  Neutrino scattering Reduced Cross-Section (light)
 *
-      elseif(obs(1:9).eq."DIS_SNU_L")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("neutrino")
-         call SetTargetDIS("isoscalar")
-*
-****  Antineutrino scattering Reduced Cross-Section (light)
-*
-      elseif(obs(1:9).eq."DIS_SNB_L")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("antineutrino")
-         call SetTargetDIS("isoscalar")
-*
-****  Neutrino scattering Reduced Cross-Section (charm)
-*
-      elseif(obs(1:9).eq."DIS_SNU_C")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("neutrino")
-         call SetTargetDIS("isoscalar")
-*
-****  Antineutrino scattering Reduced Cross-Section (charm)
-*
-      elseif(obs(1:9).eq."DIS_SNB_C")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("antineutrino")
-         call SetTargetDIS("isoscalar")
-*
-****  Neutrino scattering Reduced Cross-Section (inclusive)
-*
-      elseif(obs(1:7).eq."DIS_SNU")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("neutrino")
-         call SetTargetDIS("isoscalar")
-*
-****  Antineutrino scattering Reduced Cross-Section (inclusive)
-*
-      elseif(obs(1:7).eq."DIS_SNB")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("antineutrino")
-         call SetTargetDIS("isoscalar")
-*
-****  Neutrino scattering Reduced Cross-Section (light)
-*
       elseif(obs(1:12).eq."DIS_SNU_L_Pb")then
          call SetProcessDIS("CC")
          call SetProjectileDIS("neutrino")
@@ -357,6 +315,48 @@
          call SetProcessDIS("CC")
          call SetProjectileDIS("antineutrino")
          call SetTargetDIS("lead")
+*
+****  Neutrino scattering Reduced Cross-Section (light)
+*
+      elseif(obs(1:9).eq."DIS_SNU_L")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("neutrino")
+         call SetTargetDIS("isoscalar")
+*
+****  Antineutrino scattering Reduced Cross-Section (light)
+*
+      elseif(obs(1:9).eq."DIS_SNB_L")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("antineutrino")
+         call SetTargetDIS("isoscalar")
+*
+****  Neutrino scattering Reduced Cross-Section (charm)
+*
+      elseif(obs(1:9).eq."DIS_SNU_C")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("neutrino")
+         call SetTargetDIS("isoscalar")
+*
+****  Antineutrino scattering Reduced Cross-Section (charm)
+*
+      elseif(obs(1:9).eq."DIS_SNB_C")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("antineutrino")
+         call SetTargetDIS("isoscalar")
+*
+****  Neutrino scattering Reduced Cross-Section (inclusive)
+*
+      elseif(obs(1:7).eq."DIS_SNU")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("neutrino")
+         call SetTargetDIS("isoscalar")
+*
+****  Antineutrino scattering Reduced Cross-Section (inclusive)
+*
+      elseif(obs(1:7).eq."DIS_SNB")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("antineutrino")
+         call SetTargetDIS("isoscalar")
 *
 ****  Dimuon neutrino cross section
 *


### PR DESCRIPTION
@vbertone So che mi hai detto esplicitamente di non chiederti nulla a proposito di APFEL, tuttavia ho recentemente riscontrato un piccolo baco che ha a che fare con la non-isoscalarita' per CHORUS. Si tratta semplicemente di invertire l'ordine delle osservabili (prima quelle col suffisso _Pb, poi quelle senza). Spero che tu possa approvare questa PR.