### PR TITLE
small fix for python 3 compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -20427,7 +20427,7 @@ fi
   if test -x "$PYTHON"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python include path" >&5
 $as_echo_n "checking for Python include path... " >&6; }
-    python_incpath=`$PYTHON -c "import distutils.sysconfig; print distutils.sysconfig.get_python_inc();"`
+    python_incpath=`$PYTHON -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc());"`
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $python_incpath" >&5
 $as_echo "$python_incpath" >&6; }
     python_header="$python_incpath/Python.h"


### PR DESCRIPTION
I haven't actually tested it because I've never used the python wrapper, but just so it compiles in my computer without having to do anything manually. A convenience-laziness feature.