### PR TITLE
F2C_CCE and F2C_CCP

### DIFF
--- a/src/DIS/FKObservables.f
+++ b/src/DIS/FKObservables.f
@@ -159,12 +159,7 @@
 ****  Charm structure function F2charm
 *
       elseif(obs(1:7).eq."DIS_F2C")then
-         FKObservables = F2charm(x)
-*
-****  Charm structure function F3charm
-*
-      elseif(obs(1:7).eq."DIS_F3C")then
-         FKObservables = F3charm(x)      
+         FKObservables = F2charm(x)    
 *
 ****  Bottom structure function F2bottom
 *
@@ -190,6 +185,16 @@
 *
       elseif(obs(1:7).eq."DIS_F2D")then
          FKObservables = F2total(x)
+*
+****  Proton structure function F2 (charm, CC, W-)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCE")then
+         FKObservables = F2charm(x)
+*
+****  Proton structure function F2 (charm, CC, W+)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCP")then
+         FKObservables = F2charm(x)         
 *
 ****  Light structure function FLlight
 *
@@ -231,6 +236,11 @@
 *
       elseif(obs(1:10).eq."DIS_F3P_NC")then
          FKObservables = F3total(x)
+*
+****  Charm structure function F3charm
+*
+      elseif(obs(1:7).eq."DIS_F3C")then
+         FKObservables = F3charm(x)           
 *
 ****  Electron scattering Reduced Cross-Section (light)
 *

--- a/src/DIS/FKObservables.f
+++ b/src/DIS/FKObservables.f
@@ -235,12 +235,7 @@
 ****  F3 structure function
 *
       elseif(obs(1:10).eq."DIS_F3P_NC")then
-         FKObservables = F3total(x)
-*
-****  Charm structure function F3charm
-*
-      elseif(obs(1:7).eq."DIS_F3C")then
-         FKObservables = F3charm(x)           
+         FKObservables = F3total(x)           
 *
 ****  Electron scattering Reduced Cross-Section (light)
 *

--- a/src/DIS/FKObservables.f
+++ b/src/DIS/FKObservables.f
@@ -156,6 +156,16 @@
       elseif(obs(1:7).eq."DIS_F2S")then
          FKObservables = F2light(x)
 *
+****  Proton structure function F2 (charm, CC, W-)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCE")then
+         FKObservables = F2charm(x)
+*
+****  Proton structure function F2 (charm, CC, W+)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCP")then
+         FKObservables = F2charm(x)        
+*
 ****  Charm structure function F2charm
 *
       elseif(obs(1:7).eq."DIS_F2C")then
@@ -184,17 +194,7 @@
 ****  Deuteron structure function F2
 *
       elseif(obs(1:7).eq."DIS_F2D")then
-         FKObservables = F2total(x)
-*
-****  Proton structure function F2 (charm, CC, W-)
-*
-      elseif(obs(1:11).eq."DIS_F2C_CCE")then
-         FKObservables = F2charm(x)
-*
-****  Proton structure function F2 (charm, CC, W+)
-*
-      elseif(obs(1:11).eq."DIS_F2C_CCP")then
-         FKObservables = F2charm(x)         
+         FKObservables = F2total(x)         
 *
 ****  Light structure function FLlight
 *

--- a/src/DIS/FKObservables.f
+++ b/src/DIS/FKObservables.f
@@ -161,6 +161,11 @@
       elseif(obs(1:7).eq."DIS_F2C")then
          FKObservables = F2charm(x)
 *
+****  Charm structure function F3charm
+*
+      elseif(obs(1:7).eq."DIS_F3C")then
+         FKObservables = F3charm(x)      
+*
 ****  Bottom structure function F2bottom
 *
       elseif(obs(1:7).eq."DIS_F2B")then

--- a/src/DIS/FKSimulator.f
+++ b/src/DIS/FKSimulator.f
@@ -220,12 +220,7 @@
 ****  F3 structure function
 *
       elseif(obs(1:10).eq."DIS_F3P_NC")then
-         FKSimulator = ExternalDISOperator("F3",7,i,x,beta)
-*
-****  Charm structure function F3charm
-*
-      elseif(obs(1:7).eq."DIS_F3C")then
-         FKSimulator = ExternalDISOperator("F3",4,i,x,beta)         
+         FKSimulator = ExternalDISOperator("F3",7,i,x,beta)        
 *
 ****  Electron scattering Reduced Cross-Section (light)
 *

--- a/src/DIS/FKSimulator.f
+++ b/src/DIS/FKSimulator.f
@@ -141,11 +141,20 @@
       elseif(obs(1:7).eq."DIS_F2S")then
          FKSimulator = ExternalDISOperator("F2",3,i,x,beta)
 *
+****  Proton structure function F2 (charm, CC, W-)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCE")then
+         FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
+*
+****  Proton structure function F2 (charm, CC, W+)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCP")then
+         FKSimulator = ExternalDISOperator("F2",4,i,x,beta)         
+*
 ****  Charm structure function F2charm
 *
       elseif(obs(1:7).eq."DIS_F2C")then
          FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
-
 *
 ****  Bottom structure function F2bottom
 *
@@ -161,16 +170,6 @@
 *
       elseif(obs(1:7).eq."DIS_F2D")then
          FKSimulator = ExternalDISOperator("F2",7,i,x,beta)
-*
-****  Proton structure function F2 (charm, CC, W-)
-*
-      elseif(obs(1:11).eq."DIS_F2C_CCE")then
-         FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
-*
-****  Proton structure function F2 (charm, CC, W+)
-*
-      elseif(obs(1:11).eq."DIS_F2C_CCP")then
-         FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
 *
 ****  Light structure function FLlight
 *

--- a/src/DIS/FKSimulator.f
+++ b/src/DIS/FKSimulator.f
@@ -146,6 +146,11 @@
       elseif(obs(1:7).eq."DIS_F2C")then
          FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
 *
+****  Charm structure function F3charm
+*
+      elseif(obs(1:7).eq."DIS_F3C")then
+         FKSimulator = ExternalDISOperator("F3",4,i,x,beta)
+*
 ****  Bottom structure function F2bottom
 *
       elseif(obs(1:7).eq."DIS_F2B")then

--- a/src/DIS/FKSimulator.f
+++ b/src/DIS/FKSimulator.f
@@ -145,11 +145,7 @@
 *
       elseif(obs(1:7).eq."DIS_F2C")then
          FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
-*
-****  Charm structure function F3charm
-*
-      elseif(obs(1:7).eq."DIS_F3C")then
-         FKSimulator = ExternalDISOperator("F3",4,i,x,beta)
+
 *
 ****  Bottom structure function F2bottom
 *
@@ -165,6 +161,16 @@
 *
       elseif(obs(1:7).eq."DIS_F2D")then
          FKSimulator = ExternalDISOperator("F2",7,i,x,beta)
+*
+****  Proton structure function F2 (charm, CC, W-)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCE")then
+         FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
+*
+****  Proton structure function F2 (charm, CC, W+)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCP")then
+         FKSimulator = ExternalDISOperator("F2",4,i,x,beta)
 *
 ****  Light structure function FLlight
 *
@@ -216,6 +222,11 @@
 *
       elseif(obs(1:10).eq."DIS_F3P_NC")then
          FKSimulator = ExternalDISOperator("F3",7,i,x,beta)
+*
+****  Charm structure function F3charm
+*
+      elseif(obs(1:7).eq."DIS_F3C")then
+         FKSimulator = ExternalDISOperator("F3",4,i,x,beta)         
 *
 ****  Electron scattering Reduced Cross-Section (light)
 *

--- a/src/DIS/SetFKObservable.f
+++ b/src/DIS/SetFKObservable.f
@@ -67,6 +67,20 @@
          call SetProjectileDIS("electron")
          call SetTargetDIS("proton")
 *
+****  Proton structure function F2 (charm, CC, W-)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCE")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("electron")
+         call SetTargetDIS("proton")
+*
+****  Proton structure function F2 (charm, CC, W+)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCP")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("positron")
+         call SetTargetDIS("proton")  
+*
 ****  Charm structure function F2charm
 *
       elseif(obs(1:7).eq."DIS_F2C")then
@@ -142,21 +156,7 @@
       elseif(obs(1:7).eq."DIS_F2P")then
          call SetProcessDIS("EM")
          call SetProjectileDIS("electron")
-         call SetTargetDIS("proton")
-*
-****  Proton structure function F2 (charm, CC, W-)
-*
-      elseif(obs(1:11).eq."DIS_F2C_CCE")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("electron")
-         call SetTargetDIS("proton")
-*
-****  Proton structure function F2 (charm, CC, W+)
-*
-      elseif(obs(1:11).eq."DIS_F2C_CCP")then
-         call SetProcessDIS("CC")
-         call SetProjectileDIS("positron")
-         call SetTargetDIS("proton")         
+         call SetTargetDIS("proton")       
 *
 ****  Proton structure function FL (Neutral current)
 *

--- a/src/DIS/SetFKObservable.f
+++ b/src/DIS/SetFKObservable.f
@@ -77,7 +77,7 @@
 ****  Charm structure function F3charm
 *
       elseif(obs(1:7).eq."DIS_F3C")then
-         call SetProcessDIS("EM")
+         call SetProcessDIS("NC")
          call SetProjectileDIS("electron")
          call SetTargetDIS("proton")         
 *

--- a/src/DIS/SetFKObservable.f
+++ b/src/DIS/SetFKObservable.f
@@ -74,6 +74,13 @@
          call SetProjectileDIS("electron")
          call SetTargetDIS("proton")
 *
+****  Charm structure function F3charm
+*
+      elseif(obs(1:7).eq."DIS_F3C")then
+         call SetProcessDIS("EM")
+         call SetProjectileDIS("electron")
+         call SetTargetDIS("proton")         
+*
 ****  Bottom structure function F2bottom
 *
       elseif(obs(1:7).eq."DIS_F2B")then

--- a/src/DIS/SetFKObservable.f
+++ b/src/DIS/SetFKObservable.f
@@ -72,14 +72,7 @@
       elseif(obs(1:7).eq."DIS_F2C")then
          call SetProcessDIS("EM")
          call SetProjectileDIS("electron")
-         call SetTargetDIS("proton")
-*
-****  Charm structure function F3charm
-*
-      elseif(obs(1:7).eq."DIS_F3C")then
-         call SetProcessDIS("NC")
-         call SetProjectileDIS("electron")
-         call SetTargetDIS("proton")         
+         call SetTargetDIS("proton")        
 *
 ****  Bottom structure function F2bottom
 *
@@ -151,6 +144,20 @@
          call SetProjectileDIS("electron")
          call SetTargetDIS("proton")
 *
+****  Proton structure function F2 (charm, CC, W-)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCE")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("electron")
+         call SetTargetDIS("proton")
+*
+****  Proton structure function F2 (charm, CC, W+)
+*
+      elseif(obs(1:11).eq."DIS_F2C_CCP")then
+         call SetProcessDIS("CC")
+         call SetProjectileDIS("positron")
+         call SetTargetDIS("proton")         
+*
 ****  Proton structure function FL (Neutral current)
 *
       elseif(obs(1:10).eq."DIS_FLP_NC".or.
@@ -172,6 +179,13 @@
          call SetProcessDIS("NC")
          call SetProjectileDIS("electron")
          call SetTargetDIS("proton")
+*
+****  Charm structure function F3charm
+*
+      elseif(obs(1:7).eq."DIS_F3C")then
+         call SetProcessDIS("NC")
+         call SetProjectileDIS("electron")
+         call SetTargetDIS("proton")          
 *
 ****  Electron scattering Reduced Cross-Section (light)
 *

--- a/src/DIS/SetFKObservable.f
+++ b/src/DIS/SetFKObservable.f
@@ -178,14 +178,7 @@
       elseif(obs(1:10).eq."DIS_F3P_NC")then
          call SetProcessDIS("NC")
          call SetProjectileDIS("electron")
-         call SetTargetDIS("proton")
-*
-****  Charm structure function F3charm
-*
-      elseif(obs(1:7).eq."DIS_F3C")then
-         call SetProcessDIS("NC")
-         call SetProjectileDIS("electron")
-         call SetTargetDIS("proton")          
+         call SetTargetDIS("proton")         
 *
 ****  Electron scattering Reduced Cross-Section (light)
 *


### PR DESCRIPTION
This PR contains the implementation of two observables, F2C^{p,W+} and F2C^{p,W-}. These are needed to generate positivity observables for a NNPDF fit in which the c and cbar PDFs are parametrised independently.