### PR TITLE
Some changes to cmake build system to simplify the flags treatment and the python installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ cmake_policy(SET CMP0078 OLD)
 project(apfel LANGUAGES CXX Fortran)
 set(apfel_VERSION 3.0.7)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
-#This module respects HFS, e.g. defines lib or lib64 when it is needed.
 include("GNUInstallDirs")
 
 option(APFEL_ENABLE_PYTHON      "Enables building of python bindings" ON)
@@ -26,6 +25,13 @@ add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-unused-parameter>")
 if (NOT DEFINED CMAKE_MACOSX_RPATH)
    set(CMAKE_MACOSX_RPATH 0)
 endif()
+
+message(STATUS "APFEL: CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}")
+message(STATUS "APFEL: CMAKE_Fortran_COMPILER_ID=${CMAKE_Fortran_COMPILER_ID}")
+message(STATUS "APFEL: APFEL_ENABLE_PYTHON=${APFEL_ENABLE_PYTHON}")
+message(STATUS "APFEL: APFEL_ENABLE_TESTS=${APFEL_ENABLE_TESTS}")
+message(STATUS "APFEL: APFEL_ENABLE_LHAPDF=${APFEL_ENABLE_LHAPDF}")
+message(STATUS "APFEL: APFEL_DOWNLOAD_PDFS=${APFEL_DOWNLOAD_PDFS}")
 
 # CONFIG SCRIPT =========================================================================
 
@@ -45,7 +51,10 @@ configure_file("${PROJECT_SOURCE_DIR}/include/APFEL/FortranWrappers.h.cmake" "${
 
 # LHAPDF
 if (APFEL_ENABLE_LHAPDF)
-find_program(LHAPDF_CONFIG lhapdf-config)
+  find_program(LHAPDF_CONFIG lhapdf-config)
+  if (LHAPDF_CONFIG)
+    message(STATUS "APFEL: lhapdf-config found in  ${LHAPDF_CONFIG}.")
+  endif()
 endif()
 if (LHAPDF_CONFIG AND APFEL_ENABLE_LHAPDF)
   exec_program(${LHAPDF_CONFIG}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,27 @@
 # BASIC DEFINITIONS ========================================================================
 
 # define minimum version of cmake
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15)
 
 cmake_policy(SET CMP0086 OLD)
 cmake_policy(SET CMP0078 OLD)
 
 # define project name, version and its languages
-project(apfel CXX Fortran)
+project(apfel LANGUAGES CXX Fortran)
 set(apfel_VERSION 3.0.7)
+set(CMAKE_VERBOSE_MAKEFILE OFF)
+#This module respects HFS, e.g. defines lib or lib64 when it is needed.
+include("GNUInstallDirs")
 
-# define c++ standard and issue all the warning demanded by this standard
+option(APFEL_ENABLE_PYTHON      "Enables building of python bindings" ON)
+option(APFEL_ENABLE_TESTS       "Enables testing" ON)
+option(APFEL_ENABLE_LHAPDF      "Enables LHAPDF" ON)
+option(APFEL_DOWNLOAD_PDFS      "Download LHAPDF sets" ON)
+
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fPIC")
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fPIC -cpp")
-set(CMAKE_SHARED_LINKER_FLAGS -w)
+add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wall>")
+add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wextra>")
+add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-unused-parameter>")
 
 if (NOT DEFINED CMAKE_MACOSX_RPATH)
    set(CMAKE_MACOSX_RPATH 0)
@@ -28,20 +32,22 @@ endif()
 # Configuration script
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "${prefix}")
-set(includedir "${prefix}/include")
-set(libdir "${prefix}/lib")
+set(includedir "${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(libdir "${prefix}/${CMAKE_INSTALL_LIBDIR}")
 set(PACKAGE_VERSION "${apfel_VERSION}")
-configure_file("${PROJECT_SOURCE_DIR}/bin/apfel-config.in" "${PROJECT_SOURCE_DIR}/bin/apfel-config")
+configure_file("${PROJECT_SOURCE_DIR}/bin/apfel-config.in" "${PROJECT_BINARY_DIR}/bin/apfel-config")
 
 # Fortran wrappers =========================================================================
 
-configure_file("${PROJECT_SOURCE_DIR}/include/APFEL/FortranWrappers.h.cmake" "${PROJECT_SOURCE_DIR}/include/APFEL/FortranWrappers.h")
+configure_file("${PROJECT_SOURCE_DIR}/include/APFEL/FortranWrappers.h.cmake" "${PROJECT_BINARY_DIR}/include/APFEL/FortranWrappers.h")
 
 # FINALIZE ==================================================================================
 
 # LHAPDF
+if (APFEL_ENABLE_LHAPDF)
 find_program(LHAPDF_CONFIG lhapdf-config)
-if (LHAPDF_CONFIG)
+endif()
+if (LHAPDF_CONFIG AND APFEL_ENABLE_LHAPDF)
   exec_program(${LHAPDF_CONFIG}
     ARGS --cxxflags
     OUTPUT_VARIABLE LHAPDF_CXX_FLAGS
@@ -52,45 +58,50 @@ if (LHAPDF_CONFIG)
     OUTPUT_VARIABLE LHAPDF_LIBRARIES
   )
   set(LHAPDF_LIBRARIES ${LHAPDF_LIBRARIES} CACHE STRING INTERNAL)
-else(LHAPDF_CONFIG)
+else()
   add_compile_definitions(NOLHAPDF)
-  message("LHAPDF not found!")
-endif(LHAPDF_CONFIG)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LHAPDF_CXX_FLAGS} -Wall -fPIC -Wunused")
+  message("LHAPDF is disabled of not found!")
+endif()
 
 # generate list of source files
-file(GLOB_RECURSE  source_files src/* ccwrap/*)
+file(GLOB_RECURSE  source_files_cxx src/*/*.cc ccwrap/*.cc)
+file(GLOB_RECURSE  source_files_fortran src/*/*.f ccwrap/*.f)
+set_source_files_properties( ${source_files_fortran}  PROPERTIES Fortran_PREPROCESS ON )
 
 # Add swig subdirectory
-add_subdirectory(pywrap)
+if (APFEL_ENABLE_PYTHON)
+  add_subdirectory(pywrap)
+endif()
 
-add_library(apfel SHARED ${source_files})
+add_library(APFEL SHARED ${source_files_cxx} ${source_files_fortran})
 
 # include directory
 include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_BINARY_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
 # define libraries to be linked
-target_link_libraries(apfel ${LHAPDF_LIBRARIES})
+target_link_libraries(APFEL ${LHAPDF_LIBRARIES})
+target_compile_features(APFEL PRIVATE cxx_std_11)
+set_target_properties(APFEL PROPERTIES 
+    ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/$<0:>
+    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/$<0:>
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/$<0:>
+    )
 
 # build test codes
-enable_testing()
-add_subdirectory(examples)
-
-# define target library
-set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
+if (APFEL_ENABLE_TESTS)
+ enable_testing()
+ add_subdirectory(examples)
+endif()
 
 # install
-install(TARGETS apfel
-           RUNTIME DESTINATION bin
-           LIBRARY DESTINATION lib)
-install(DIRECTORY include/APFEL DESTINATION include)
-install(FILES ${PROJECT_SOURCE_DIR}/bin/apfel-config
-${CMAKE_CURRENT_BINARY_DIR}/examples/CheckAPFEL ${CMAKE_CURRENT_BINARY_DIR}/examples/ListFunctions DESTINATION bin
+install(TARGETS APFEL DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(DIRECTORY include/APFEL DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.h")
+install(FILES ${PROJECT_BINARY_DIR}/include/APFEL/FortranWrappers.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/APFEL/ )
+install(FILES ${PROJECT_BINARY_DIR}/bin/apfel-config
+${CMAKE_CURRENT_BINARY_DIR}/examples/CheckAPFEL ${CMAKE_CURRENT_BINARY_DIR}/examples/ListFunctions DESTINATION ${CMAKE_INSTALL_BINDIR}
 PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
 GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
-execute_process(COMMAND python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
-install(TARGETS _apfel DESTINATION ${PYTHON_SITE_PACKAGES})
-install(FILES ${CMAKE_BINARY_DIR}/pywrap/apfel.py DESTINATION ${PYTHON_SITE_PACKAGES})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,16 +1,38 @@
 # build tests
-file(GLOB testcodes *.f)
+
+file(GLOB testcodes *.cc *.f)
 foreach(testsource ${testcodes})
   GET_FILENAME_COMPONENT(filename ${testsource} NAME_WE)
-  add_executable(${filename} ${filename}.f)
-  target_link_libraries(${filename} apfel)
-  add_test(${filename} ${filename})
+  add_executable(${filename} ${testsource})
+  target_link_libraries(${filename} APFEL)
+  if (${filename} STREQUAL "Timing" )
+    add_test(NAME ${filename}  COMMAND sh -c "${CMAKE_CURRENT_BINARY_DIR}/${filename} 2 QCD" )
+  elseif (${filename} STREQUAL "TabulationStep" )
+    #add_test(NAME ${filename}  COMMAND sh -c "${CMAKE_CURRENT_BINARY_DIR}/${filename}  <${CMAKE_CURRENT_SOURCE_DIR}/input.txt" )
+  elseif (${filename} STREQUAL "TabulationStepCxx" )
+    #add_test(NAME ${filename}  COMMAND sh -c "${CMAKE_CURRENT_BINARY_DIR}/${filename}  <${CMAKE_CURRENT_SOURCE_DIR}/input.txt" )
+  else()
+    add_test(NAME ${filename}  COMMAND sh -c "${CMAKE_CURRENT_BINARY_DIR}/${filename} <${CMAKE_CURRENT_SOURCE_DIR}/input.txt" )
+  endif()
 endforeach()
 
-file(GLOB testcodes *.cc)
-foreach(testsource ${testcodes})
-  GET_FILENAME_COMPONENT(filename ${testsource} NAME_WE)
-  add_executable(${filename} ${filename}.cc)
-  target_link_libraries(${filename} apfel)
-  add_test(${filename} ${filename})
-endforeach()
+
+if (APFEL_DOWNLOAD_PDFS AND APFEL_ENABLE_LHAPDF)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PDFS)
+  file(DOWNLOAD https://lhapdfsets.web.cern.ch/current/NNPDF23_nlo_as_0118.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118.tar.gz)
+  file(DOWNLOAD https://lhapdfsets.web.cern.ch/current/NNPDF31_nnlo_as_0118.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118.tar.gz)
+  add_custom_target( UNZIPPDFS ALL)
+  add_custom_command(TARGET UNZIPPDFS PRE_BUILD 
+         COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118
+         COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118
+         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118.tar.gz
+         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118.tar.gz
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PDFS
+         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118.tar.gz
+         COMMENT "Unpacking PDFs"
+         VERBATIM)
+  foreach( t LHgridDerivativeProduction LHgridProduction LHgridDerivativeProductionCxx)
+    set_tests_properties( ${t} PROPERTIES ENVIRONMENT "LHAPDF_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/PDFS" DEPENDS UNZIPPDFS)
+  endforeach()
+
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,7 @@ foreach(testsource ${testcodes})
   GET_FILENAME_COMPONENT(filename ${testsource} NAME_WE)
   add_executable(${filename} ${testsource})
   target_link_libraries(${filename} APFEL)
+  #Different tests require different arguments.
   if (${filename} STREQUAL "Timing" )
     add_test(NAME ${filename}  COMMAND sh -c "${CMAKE_CURRENT_BINARY_DIR}/${filename} 2 QCD" )
   elseif (${filename} STREQUAL "TabulationStep" )
@@ -16,7 +17,8 @@ foreach(testsource ${testcodes})
   endif()
 endforeach()
 
-
+# This will download the needed PDFS, unpack them into a build directory and makes the LHAPDF to use those PDFS.
+# This approach is important when user cannot or does not want to install the PDFs in the standard location.
 if (APFEL_DOWNLOAD_PDFS AND APFEL_ENABLE_LHAPDF)
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PDFS)
   file(DOWNLOAD https://lhapdfsets.web.cern.ch/current/NNPDF23_nlo_as_0118.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118.tar.gz)

--- a/pywrap/CMakeLists.txt
+++ b/pywrap/CMakeLists.txt
@@ -3,16 +3,16 @@ find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
 # Include python
-find_package(PythonLibs REQUIRED)
-include_directories(${PYTHON_INCLUDE_PATH})
+find_package(Python  COMPONENTS Interpreter Development REQUIRED)
 
 set(CMAKE_SWIG_FLAGS "")
-set_source_files_properties(${PROJECT_NAME}.i PROPERTIES CPLUSPLUS ON)
-include_directories(../include/)
+set_source_files_properties(${PROJECT_NAME}.i PROPERTIES CPLUSPLUS ON  OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include/)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../include/)
 
 # Add swig module
 swig_add_library(apfel LANGUAGE python SOURCES ${PROJECT_NAME}.i)
-swig_link_libraries(apfel ${PROJECT_NAME} ${PYTHON_LIBRARIES})
+swig_link_libraries(apfel APFEL Python::Module)
 
 # Files to install with Python
 set(PYTHON_INSTALL_FILES
@@ -20,11 +20,24 @@ set(PYTHON_INSTALL_FILES
         ${CMAKE_CURRENT_BINARY_DIR}/_apfel.so)
 
 # Configure setup.py and copy to output directory
-set(SETUP_PY_IN ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in)
-set(SETUP_PY_OUT ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
-configure_file(${SETUP_PY_IN} ${SETUP_PY_OUT})
+
+set(srcdir ${CMAKE_CURRENT_BINARY_DIR})
+set(top_srcdir ${PROJECT_SOURCE_DIR})
+set(top_builddir ${PROJECT_BINARY_DIR})
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
+
+
+if (NOT APFEL_Python_SITEARCH)
+ set(APFEL_Python_SITEARCH ${Python_SITEARCH})
+endif()
+if ( "${APFEL_Python_SITEARCH}" STREQUAL "prefix")
+ set(APFEL_Python_SITEARCH "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/")
+endif()
+install(TARGETS _apfel DESTINATION ${APFEL_Python_SITEARCH})
+install(FILES ${CMAKE_BINARY_DIR}/pywrap/apfel.py DESTINATION ${APFEL_Python_SITEARCH})
+
 
 # Install target to call setup.py
 add_custom_target(install-python
         DEPENDS _apfel
-        COMMAND python ${SETUP_PY_OUT} install)
+        COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py  install --prefix=${APFEL_Python_SITEARCH})

--- a/pywrap/CMakeLists.txt
+++ b/pywrap/CMakeLists.txt
@@ -2,8 +2,12 @@
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
+message(STATUS "APFEL python: SWIG version ${SWIG_VERSION} found in ${SWIG_EXECUTABLE}.")
+
+
 # Include python
 find_package(Python  COMPONENTS Interpreter Development REQUIRED)
+message(STATUS "APFEL python: Python version ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR} found in ${Python_EXECUTABLE}.")
 
 set(CMAKE_SWIG_FLAGS "")
 set_source_files_properties(${PROJECT_NAME}.i PROPERTIES CPLUSPLUS ON  OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -11,33 +15,46 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include/)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/../include/)
 
 # Add swig module
+# Please note that the line below will generate apfelPYTHON_wrap.cxx file in the CMAKE_CURRENT_BINARY_DIR
 swig_add_library(apfel LANGUAGE python SOURCES ${PROJECT_NAME}.i)
 swig_link_libraries(apfel APFEL Python::Module)
 
-# Files to install with Python
-set(PYTHON_INSTALL_FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/apfel.py
-        ${CMAKE_CURRENT_BINARY_DIR}/_apfel.so)
-
-# Configure setup.py and copy to output directory
-
-set(srcdir ${CMAKE_CURRENT_BINARY_DIR})
-set(top_srcdir ${PROJECT_SOURCE_DIR})
-set(top_builddir ${PROJECT_BINARY_DIR})
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
-
+# Write meta-info file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/apfel-${apfel_VERSION}-py${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}.egg-info
+"Metadata-Version: 2.1\n\
+Name: APFEL\n\
+Version: ${apfel_VERSION}\n\
+Summary: A PDF Evolution Library\n\
+Home-page: https://github.com/scarazza/apfel\n\
+Author: ['Valerio Bertone']\n\
+Author-email: valerio.bertone@cern.ch\n\
+License: GPL\n\
+Keywords: PDFs,FFs,DGLAP,DIS,structure functions\n\
+\n\
+This is a simple SWIG wrapper on the main steering interface of\n\
+the APFEL library. It is used to create, query and use the APFEL data from\n\
+a Python program.")
 
 if (NOT APFEL_Python_SITEARCH)
- set(APFEL_Python_SITEARCH ${Python_SITEARCH})
+  set(APFEL_Python_SITEARCH ${Python_SITEARCH})
+  message(STATUS "APFEL python: WARNING: The installation path of the python modules is APFEL_Python_SITEARCH=${APFEL_Python_SITEARCH}.")
+  message(STATUS "APFEL python: WARNING: The installation path of the python modules is outside of the global instalation path CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}.")
+  message(STATUS "APFEL python: WARNING: The installation path of the python modules might be not writable by the current user.")
+  message(STATUS "APFEL python: WARNING: You can use the APFEL_Python_SITEARCH variable to set the desired installation path for the Python modules.")
+  message(STATUS "APFEL python: WARNING: Alternatively you can use -DAPFEL_Python_SITEARCH=autoprefix to put the python modules in the CMAKE_INSTALL_PREFIX directory.")
+elseif ( "${APFEL_Python_SITEARCH}" STREQUAL "autoprefix")
+  set(APFEL_Python_SITEARCH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/")
+  message(STATUS "APFEL python: WARNING: The installation path of the python modules is APFEL_Python_SITEARCH=${APFEL_Python_SITEARCH} is inside the CMAKE_INSTALL_PREFIX.")
+  message(STATUS "APFEL python: WARNING: Don't forget to add this location to your PYTHONPATH.")
+else()
+  message(STATUS "APFEL python: The installation path of the python modules is APFEL_Python_SITEARCH=${APFEL_Python_SITEARCH} is set by the user.")
+  message(STATUS "APFEL python: Don't forget to add this location to your PYTHONPATH.")
+  if (NOT IS_ABSOLUTE ${APFEL_Python_SITEARCH})
+    message(STATUS "APFEL python: WARNING: The path APFEL_Python_SITEARCH=${APFEL_Python_SITEARCH} is not absolute! It is recommented to use absolute path!")
+  endif()
 endif()
-if ( "${APFEL_Python_SITEARCH}" STREQUAL "prefix")
- set(APFEL_Python_SITEARCH "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/")
-endif()
-install(TARGETS _apfel DESTINATION ${APFEL_Python_SITEARCH})
-install(FILES ${CMAKE_BINARY_DIR}/pywrap/apfel.py DESTINATION ${APFEL_Python_SITEARCH})
-
-
-# Install target to call setup.py
-add_custom_target(install-python
-        DEPENDS _apfel
-        COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py  install --prefix=${APFEL_Python_SITEARCH})
+# Do manual instalation and don't rely on the python tools
+# This renders the setup.py.in obsolete.
+install(TARGETS _apfel DESTINATION ${APFEL_Python_SITEARCH}/apfel)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apfel-${apfel_VERSION}-py${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}.egg-info DESTINATION ${APFEL_Python_SITEARCH})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apfel.py DESTINATION ${APFEL_Python_SITEARCH}/apfel)

--- a/pywrap/setup.py.in
+++ b/pywrap/setup.py.in
@@ -57,3 +57,4 @@ setup(name = 'APFEL',
       keywords = 'PDFs, FFs, DGLAP, DIS, structure functions',
       license = 'GPL',
       )
+

--- a/pywrap/setup.py.in
+++ b/pywrap/setup.py.in
@@ -11,7 +11,7 @@ a Python program.
 
 ## Extension definition
 import os
-wrapsrc = '@srcdir@/apfel_wrap.cc'
+wrapsrc = '@srcdir@/apfelPYTHON_wrap.cxx'
 incdir_src = os.path.abspath('@top_srcdir@/include')
 incdir_build = os.path.abspath('@top_builddir@/include')
 libdir = os.path.abspath('@top_builddir@/lib')
@@ -29,7 +29,7 @@ if status == 0:
     ext = Extension('_apfel',
                 [wrapsrc],
                 include_dirs=[incdir_src, incdir_build],
-                library_dirs=[libdir, os.path.join(libdir,'.libs'), lhapdfdir.replace('\n','')],
+                library_dirs=[libdir,libdir+"64", os.path.join(libdir,'.libs'), lhapdfdir.replace('\n','')],
                 extra_compile_args = cxxargs,
                 extra_link_args = ldargs,
                 libraries=['APFEL','LHAPDF'])

--- a/pywrap/setup.py.in
+++ b/pywrap/setup.py.in
@@ -11,7 +11,7 @@ a Python program.
 
 ## Extension definition
 import os
-wrapsrc = '@srcdir@/apfelPYTHON_wrap.cxx'
+wrapsrc = '@srcdir@/apfel_wrap.cc'
 incdir_src = os.path.abspath('@top_srcdir@/include')
 incdir_build = os.path.abspath('@top_builddir@/include')
 libdir = os.path.abspath('@top_builddir@/lib')
@@ -29,7 +29,7 @@ if status == 0:
     ext = Extension('_apfel',
                 [wrapsrc],
                 include_dirs=[incdir_src, incdir_build],
-                library_dirs=[libdir,libdir+"64", os.path.join(libdir,'.libs'), lhapdfdir.replace('\n','')],
+                library_dirs=[libdir, os.path.join(libdir,'.libs'), lhapdfdir.replace('\n','')],
                 extra_compile_args = cxxargs,
                 extra_link_args = ldargs,
                 libraries=['APFEL','LHAPDF'])
@@ -57,4 +57,3 @@ setup(name = 'APFEL',
       keywords = 'PDFs, FFs, DGLAP, DIS, structure functions',
       license = 'GPL',
       )
-


### PR DESCRIPTION
Dear @scarrazza,

`apfel` is an important software that is used in many places, particularly in `SuperChic` MCEG by @LucianHL.
The `SuperChic` in a phase of intensive development now and the main dependency, `apfel`, is recompiled multiple times per day.
Therefore, it makes a lot of sense to improve the compilation process of `apfel` with e.g. amendments to the cmake build system:
 - reduce the dependence of `apfel` on the unreliable python `setuptools` in` pywrap/CMakeLists.txt`
 - add some simple informative printouts to all the cmake files 
 - add some boolean switches for the compilation with `LHAPDF` and `Python`

Hopefully you will find the changes useful.

Best regards,

Andrii
