### PR TITLE
cmake fixes and CI with cmake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 3
     - name: Install 
       run: |
-           uname -a 
-           cat /etc/issue
            yum -y install  gcc gcc-c++ gcc-gfortran make wget which cmake cmake-data cmake-filesystem lhapdf lhapdf-devel swig python-devel
     - name: Compile
       run: |
@@ -36,8 +32,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 3
     - name: Install 
       run: |
           brew install wget coreutils gcc swig

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Compile
       run: |
           cmake -S . -B BUILD -DCMAKE_INSTALL_PREFIX=$(pwd)/../INSTALL
-          cmake --build BUILD -j 2
+          cmake --build BUILD -j
           cmake --install BUILD
           ctest --test-dir BUILD -j 2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: build
+on:
+ push:
+ pull_request:
+ schedule:
+#Every 50 days at midnight 
+    - cron:  "0 0 1/600 * *"
+
+jobs:
+  compilejobFedora:
+    name: APFEL_on_Fedora
+    runs-on: ubuntu-latest
+    container:
+        image: fedora:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 3
+    - name: Install 
+      run: |
+           uname -a 
+           cat /etc/issue
+           yum -y install  gcc gcc-c++ gcc-gfortran make wget which cmake cmake-data cmake-filesystem lhapdf lhapdf-devel swig python-devel
+    - name: Compile
+      run: |
+          cmake -S . -B BUILD -DCMAKE_INSTALL_PREFIX=$(pwd)/../INSTALL
+          cmake --build BUILD -j 2
+          cmake --install BUILD
+          ctest --test-dir BUILD -j 2
+
+
+  compilejobOSX:
+    runs-on: macos-latest
+    name: APFEL_on_OSX
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 3
+    - name: Install 
+      run: |
+          brew install wget coreutils gcc swig
+          brew tap davidchall/hep
+          brew install lhapdf
+    - name: Compile
+      run: |
+          cmake -S . -B BUILD -DCMAKE_INSTALL_PREFIX=$(pwd)/../INSTALL -DCMAKE_Fortran_COMPILER=gfortran-13
+          cmake --build BUILD -j 2
+          cmake --install BUILD
+          ctest --test-dir BUILD -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,10 @@ FILE(WRITE   "${PROJECT_BINARY_DIR}/include/APFEL/FortranWrappers.h"
 #define APFEL_FORTRANWRAPPERS_H\n\
 \n\
 /* Mangling for Fortran global symbols without underscores. */\n\
-#define FC_FUNCTION(name,NAME) ${FortranCInterface_GLOBAL_PREFIX}${N}##${FortranCInterface_GLOBAL_SUFFIX} \n\
+#define FC_FUNC(name,NAME) ${FortranCInterface_GLOBAL_PREFIX}${N}##${FortranCInterface_GLOBAL_SUFFIX} \n\
 \n\
 /* Mangling for Fortran global symbols with underscores. */\n\
-#define FC_FUNCTION_(name,NAME) ${FortranCInterface_GLOBAL__PREFIX}${N_}##${FortranCInterface_GLOBAL__SUFFIX} \n\
+#define FC_FUNC_(name,NAME) ${FortranCInterface_GLOBAL__PREFIX}${N_}##${FortranCInterface_GLOBAL__SUFFIX} \n\
 #endif\n")
 
 # LHAPDF ===============================================================
@@ -90,10 +90,18 @@ if (LHAPDF_CONFIG AND APFEL_ENABLE_LHAPDF)
   )
   set(LHAPDF_CXX_FLAGS ${LHAPDF_CXX_FLAGS} CACHE STRING INTERNAL)
   exec_program(${LHAPDF_CONFIG}
-    ARGS --ldflags
-    OUTPUT_VARIABLE LHAPDF_LIBRARIES
+    ARGS --libdir
+    OUTPUT_VARIABLE LHAPDF_LIBDIR
   )
-  set(LHAPDF_LIBRARIES ${LHAPDF_LIBRARIES} CACHE STRING INTERNAL)
+  find_library(LHAPDF_LIBRARY NAMES LHAPDF PATHS ${LHAPDF_LIBDIR})
+  set(LHAPDF_LIBRARIES ${LHAPDF_LIBRARY} CACHE STRING INTERNAL)
+
+  exec_program(${LHAPDF_CONFIG}
+    ARGS --incdir
+    OUTPUT_VARIABLE LHAPDF_INCLUDE_DIRS
+  )
+  set(LHAPDF_INCLUDE_DIRS ${LHAPDF_INCLUDE_DIRS} CACHE STRING INTERNAL)
+  message(STATUS "APFEL: LHAPDF_INCLUDE_DIRS=${LHAPDF_INCLUDE_DIRS} LHAPDF_LIBRARIES=${LHAPDF_LIBRARIES}")
 else()
   add_compile_definitions(NOLHAPDF)
   message("LHAPDF is disabled of not found!")
@@ -204,8 +212,12 @@ endif()
 
 # Shared libraries  ####################################################
 add_library(APFEL SHARED ${libAPFELCCWrapObs_la_SOURCES} ${libAPFELCCWrapEvol_la_SOURCES} ${libAPFELCore_la_SOURCES})
-target_include_directories(APFEL PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+target_include_directories(APFEL PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>  ${LHAPDF_INCLUDE_DIRS})
 target_link_libraries(APFEL ${LHAPDF_LIBRARIES})
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  target_link_options(APFEL PRIVATE "LINKER:-z,defs")
+  target_link_options(APFEL PRIVATE "LINKER:-z,now")
+endif()
 target_compile_features(APFEL PRIVATE cxx_std_11)
 set_target_properties(APFEL PROPERTIES 
     ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/$<0:>
@@ -216,9 +228,13 @@ set_target_properties(APFEL PROPERTIES
     )
 add_library(APFEL::APFEL ALIAS APFEL)
 
-add_library(APFELevol SHARED ${libAPFELCCWrapEvol_la_SOURCES} ${libAPFELEvol_la_SOURCES})
-target_include_directories(APFELevol PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
-target_link_libraries(APFELevol ${LHAPDF_LIBRARIES})
+add_library(APFELevol SHARED ${libAPFELCCWrapEvol_la_SOURCES} ${libAPFELevol_la_SOURCES})
+target_include_directories(APFELevol PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>  ${LHAPDF_INCLUDE_DIRS})
+target_link_libraries(APFELevol ${LHAPDF_LIBRARIES} APFEL)
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  target_link_options(APFELevol PRIVATE "LINKER:-z,defs")
+  target_link_options(APFELevol PRIVATE "LINKER:-z,now")
+endif()
 target_compile_features(APFELevol PRIVATE cxx_std_11)
 set_target_properties(APFELevol PROPERTIES 
     ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/$<0:>
@@ -231,7 +247,7 @@ add_library(APFEL::APFELevol ALIAS APFELevol)
 
 # Static libraries  ####################################################
 add_library(APFEL_static STATIC ${libAPFELCCWrapObs_la_SOURCES} ${libAPFELCCWrapEvol_la_SOURCES} ${libAPFELCore_la_SOURCES})
-target_include_directories(APFEL_static PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+target_include_directories(APFEL_static PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>  ${LHAPDF_INCLUDE_DIRS})
 target_link_libraries(APFEL_static ${LHAPDF_LIBRARIES})
 target_compile_features(APFEL_static PRIVATE cxx_std_11)
 set_target_properties(APFEL_static PROPERTIES 
@@ -242,8 +258,8 @@ set_target_properties(APFEL_static PROPERTIES
     EXPORT_NAME APFEL::APFEL_static
     )
 
-add_library(APFELevol_static STATIC ${libAPFELCCWrapEvol_la_SOURCES} ${libAPFELEvol_la_SOURCES})
-target_include_directories(APFELevol_static PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
+add_library(APFELevol_static STATIC ${libAPFELCCWrapEvol_la_SOURCES} ${libAPFELevol_la_SOURCES})
+target_include_directories(APFELevol_static PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>  ${LHAPDF_INCLUDE_DIRS})
 target_link_libraries(APFELevol_static ${LHAPDF_LIBRARIES})
 target_compile_features(APFELevol_static PRIVATE cxx_std_11)
 set_target_properties(APFELevol_static PROPERTIES 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,20 +21,20 @@ endforeach()
 # This approach is important when user cannot or does not want to install the PDFs in the standard location.
 if (APFEL_DOWNLOAD_PDFS AND APFEL_ENABLE_LHAPDF)
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PDFS)
-  file(DOWNLOAD https://lhapdfsets.web.cern.ch/current/NNPDF23_nlo_as_0118.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118.tar.gz)
-  file(DOWNLOAD https://lhapdfsets.web.cern.ch/current/NNPDF31_nnlo_as_0118.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118.tar.gz)
-  add_custom_target( UNZIPPDFS ALL)
-  add_custom_command(TARGET UNZIPPDFS PRE_BUILD 
-         COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118
-         COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118
-         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118.tar.gz
-         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118.tar.gz
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PDFS
-         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118.tar.gz
-         COMMENT "Unpacking PDFs"
-         VERBATIM)
+  include(FetchContent)
+  FetchContent_Declare(NNPDF23_nlo_as_0118 URL https://lhapdfsets.web.cern.ch/current/NNPDF23_nlo_as_0118.tar.gz URL_HASH   MD5=139d93c4ed265d227294d8f8c72d6ef8)
+  FetchContent_GetProperties(NNPDF23_nlo_as_0118)
+  if (NOT NNPDF23_nlo_as_0118_nnlo_POPULATED)
+    FetchContent_Populate(NNPDF23_nlo_as_0118)
+    file(CREATE_LINK ${nnpdf23_nlo_as_0118_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF23_nlo_as_0118 SYMBOLIC)
+  endif()
+  FetchContent_Declare(NNPDF31_nnlo_as_0118 URL https://lhapdfsets.web.cern.ch/current/NNPDF31_nnlo_as_0118.tar.gz URL_HASH   MD5=4300488b31cd7995c1d375ed477b238e)
+  FetchContent_GetProperties(NNPDF31_nnlo_as_0118)
+  if (NOT NNPDF31_nnlo_as_0118_nnlo_POPULATED)
+    FetchContent_Populate(NNPDF31_nnlo_as_0118)
+    file(CREATE_LINK ${nnpdf31_nnlo_as_0118_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/PDFS/NNPDF31_nnlo_as_0118 SYMBOLIC)
+  endif()       
   foreach( t LHgridDerivativeProduction LHgridProduction LHgridDerivativeProductionCxx)
-    set_tests_properties( ${t} PROPERTIES ENVIRONMENT "LHAPDF_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/PDFS" DEPENDS UNZIPPDFS)
+    set_tests_properties( ${t} PROPERTIES ENVIRONMENT "LHAPDF_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/PDFS")
   endforeach()
-
 endif()


### PR DESCRIPTION
Hi @scarrazza, here is a simple CI + some cmake fixes:
- CI:
  - Runs on MacOSX in native Actions MacOS
  - Runs on latest Fedora in a Docker container
  - For both cases uses the lhapdf
  - All dependencies are installed from binary repositories
  - All options are turned on: LHAPDF, SWIG, testing
  - Workflow is quite cheap: ~ 2m30sec
  - Scheduled builds are enabled
  - Regular rebuilds with `fedora::latests` assures the most updated container with all the dependencies
 - Cmake fix:
   - The Fortran-C intrface function has a correct name
   - More advanced approach to PDF downloads, e.g. checks of checksums, which is useful when HepForge is down

Same as #45 

Tag @AleCandido