### PR TITLE
Drop CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Circle CI](https://circleci.com/gh/scarrazza/apfel/tree/master.svg?style=svg)](https://circleci.com/gh/scarrazza/apfel/tree/master)
-
 ![alt text](https://github.com/scarrazza/apfel/raw/master/resources/logoapfel.png "Logo APFEL")
 
 # APFEL: A PDF Evolution Library


### PR DESCRIPTION
My bad, this is a leftover of #48. I only realized it now.

Moreover, @scarrazza the webhook of Circle CI should be unregistered as well.
https://app.circleci.com/pipelines/github/scarrazza/apfel/49
<img width="618" alt="image" src="https://github.com/scarrazza/apfel/assets/10830876/280aab19-b11b-4b95-a21a-45d27d1e76fc">
