### PR TITLE
Update README removing autotools instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # APFEL: A PDF Evolution Library
 
 Visit: http://apfel.hepforge.org and http://apfel.mi.infn.it/
- 
+
 APFEL is a library able to perform DGLAP evolution up to NNLO in QCD
 and to NLO in QED, both with pole and MSbar masses. The coupled DGLAP
 QCD+QED evolution equations are solved in x-space by means of higher
@@ -33,39 +33,20 @@ git tag -l
 git checkout tags/tag_name
 ```
 
-## Installation 
+## Installation
+
 ### Dependencies
- - Fortran and C++ compillers.
- - (Optional) `make` for installation with `autotools`
- - (Optional) `CMake` (https://cmake.org/) > 3.16 for installation with `CMake` and any build system -- `make`, `ninja`, etc.
- - (Optional) `LHAPDF` library, for support PDFs in of Les Hauches format.
- - (Optional) `CPython` headers and `SWIG`, for compilation of Python bindings.
- - (Optional) Internet connection if the installation of PDFs was requested.
- 
-### Compilation with autotools
-Checkout the code and compile the code using the
-following procedure:
 
-```Shell
-cd apfel
-./configure --prefix=/where/install/apfel #(optional)
-make && make install
-```
-
-By the default, if prefix is not set, the program is installed in
-/usr/local. If you define a different prefix, remember to export
-it into the `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH`.
-
-#### Known issues
-
-If you observe memory issues while running APFEL on specific machines you can move the memory allocation to heap by adding the `-fno-automatic` flag:
-```bash
-export FFLAGS=$(echo $FFLAGS | sed 's/-fopenmp/-fno-automatic/g')
-./configure --prefix=$PREFIX 
-```
+- Fortran and C++ compillers.
+- (Optional) `make` for installation with `autotools`
+- (Optional) `CMake` (https://cmake.org/) > 3.16 for installation with `CMake` and any build system -- `make`, `ninja`, etc.
+- (Optional) `LHAPDF` library, for support PDFs in of Les Houches format.
+- (Optional) `CPython` headers and `SWIG`, for compilation of Python bindings.
+- (Optional) Internet connection if the installation of PDFs was requested.
 
 ### Compilation with CMake
-Checkout the code and compile the code using the
+
+Checkout the code and compile the code by using the
 following procedure:
 
 ```Shell
@@ -74,6 +55,7 @@ cmake -S . -B BUILD  <extra flags>
 cmake --build BUILD
 cmake --install BUILD
 ```
+
 and optionally, if the testing was enabled
 
 ```Shell
@@ -83,17 +65,18 @@ ctest --test-dir BUILD
 Remember to export the location of the libraries into the `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH`.
 
 The extra flags might be:
+
 - generic CMake flags, e.g. `-DCMAKE_INSTALL_PREFIX=/my/home/dir`, `-DCMAKE_Fortran_COMPILER=ifort`, `-DCMAKE_Fortran_FLAGS="-O2 -g"`, etc.
 - flags pointing to the dependencies, `-DPython_DIR=/where/the/derised/python/is`
-- flags that steer the compilation. In the current version there are the following flags: 
-   - `-DAPFEL_ENABLE_PYTHON=ON|OFF`, default=`ON`    Enables building of python bindings. Requires `SWIG` and Python headers if enabled. Tested only with CPython.
-   - `-DAPFEL_ENABLE_TESTS=ON|OFF`, default=`ON`     Enables testing
-   - `-DAPFEL_ENABLE_LHAPDF=ON|OFF`, default=`ON`    Enables compilation with `LHAPDF`. Requires `LHAPDF` if enabled.
-   - `-DAPFEL_DOWNLOAD_PDFS=ON|OFF`, default=`ON`    Download LHAPDF sets for tests. Makes sense only when the testing and compilation with LHAPDF are enabled. Requires internet connection if enabled.
-   - `-DAPFEL_Python_SITEARCH=/path/to/install/python/modules|autoprefix`, default is the python system location. If "autoprefix" is used, the modules will be installed inside 
+- flags that steer the compilation. In the current version there are the following flags:
+  - `-DAPFEL_ENABLE_PYTHON=ON|OFF`, default=`ON` Enables building of python bindings. Requires `SWIG` and Python headers if enabled. Tested only with CPython.
+  - `-DAPFEL_ENABLE_TESTS=ON|OFF`, default=`ON` Enables testing
+  - `-DAPFEL_ENABLE_LHAPDF=ON|OFF`, default=`ON` Enables compilation with `LHAPDF`. Requires `LHAPDF` if enabled.
+  - `-DAPFEL_DOWNLOAD_PDFS=ON|OFF`, default=`ON` Download LHAPDF sets for tests. Makes sense only when the testing and compilation with LHAPDF are enabled. Requires internet connection if enabled.
+  - `-DAPFEL_Python_SITEARCH=/path/to/install/python/modules|autoprefix`, default is the python system location. If "autoprefix" is used, the modules will be installed inside
     `CMAKE_INSTALL_PREFIX`. Makes sense only when the building of python bindings is enabled. Do not forget to add the location of modules to the `PYTHONPATH`.
-The `CMake` installation also provides the `CMake` config files for APFEL, therefore it if possible to
-do in the `CMakeLists.txt` of the dependant projects:
+    The `CMake` installation also provides the `CMake` config files for APFEL, therefore it if possible to
+    do in the `CMakeLists.txt` of the dependant projects:
 
 ```Shell
 find_package(apfel)
@@ -103,7 +86,9 @@ target_link_libraries(mytarget PRIVATE APFEL::APFEL APFEL::APFELevol)
 ```
 
 #### Known issues
+
 It is recommended to avoid using the source directory for the builds, i.e.
+
 ```Shell
 cmake -S . -B . # do not do this
 cmake -S . # do not do this
@@ -111,8 +96,8 @@ cmake -S . # do not do this
 
 ## References
 
-- V. Bertone, S. Carrazza, J. Rojo, *APFEL: A PDF Evolution Library with QED corrections*, [arXiv:1310.1394](http://arxiv.org/abs/arXiv:1310.1394).
-- S. Carrazza, A. Ferrara, D. Palazzo, J. Rojo, *APFEL Web: a web-based application for the graphical visualization of parton distribution functions*, [arXiv:1410.5456](http://arxiv.org/abs/1410.5456).
+- V. Bertone, S. Carrazza, J. Rojo, _APFEL: A PDF Evolution Library with QED corrections_, [arXiv:1310.1394](http://arxiv.org/abs/arXiv:1310.1394).
+- S. Carrazza, A. Ferrara, D. Palazzo, J. Rojo, _APFEL Web: a web-based application for the graphical visualization of parton distribution functions_, [arXiv:1410.5456](http://arxiv.org/abs/1410.5456).
 
 ## Contact Information
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ git checkout tags/tag_name
 ### Dependencies
 
 - Fortran and C++ compillers.
-- (Optional) `make` for installation with `autotools`
 - (Optional) `CMake` (https://cmake.org/) > 3.16 for installation with `CMake` and any build system -- `make`, `ninja`, etc.
 - (Optional) `LHAPDF` library, for support PDFs in of Les Houches format.
 - (Optional) `CPython` headers and `SWIG`, for compilation of Python bindings.
 - (Optional) Internet connection if the installation of PDFs was requested.
 
-### Compilation with CMake
+### From source
 
 Checkout the code and compile the code by using the
 following procedure:


### PR DESCRIPTION
To be rebased on top of `master`, as soon as #49 will be merged.